### PR TITLE
Test prefix tree

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,4 +22,4 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest
+        pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,8 @@ MANIFEST
 resources/traces*
 resources/prefixtree.png
 
+# Test resources
+tests/resources/traces*
+
 # Temporary Files
 temp/

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,5 @@ MANIFEST
 resources/traces*
 resources/prefixtree.png
 
-# Test resources
-tests/resources/traces*
-
 # Temporary Files
 temp/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pytest>=6.2.3
 coverage>=5.5
 tqdm>=4.60.0
 Pympler~=0.9
+networkx~=2.5.1
+matplotlib~=3.4.1

--- a/scripts/prefix_tree_generator.py
+++ b/scripts/prefix_tree_generator.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     start_time = time()
     # tracemalloc.start()
 
-    pt = PrefixTreeFactory.get_prefix_tree(str(project_root.joinpath('resources/traces')),
+    pt = PrefixTreeFactory.get_prefix_tree(str(project_root.joinpath('resources/traces_800')),
                                            str(project_root.joinpath('resources/config.json')))
 
     PrefixTreeFactory.pickle_tree(pt, project_root.joinpath('out/fullPrefixTree.p'))

--- a/scripts/prefix_tree_generator.py
+++ b/scripts/prefix_tree_generator.py
@@ -13,6 +13,9 @@ import sys
 from time import time
 import tracemalloc
 
+from whatthelog.prefixtree.visualizer import Visualizer
+
+
 sys.path.insert(0, "./../")
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -37,7 +40,7 @@ if __name__ == '__main__':
     start_time = time()
     # tracemalloc.start()
 
-    pt = PrefixTreeFactory.get_prefix_tree(str(project_root.joinpath('out/traces')),
+    pt = PrefixTreeFactory.get_prefix_tree(str(project_root.joinpath('resources/traces')),
                                            str(project_root.joinpath('resources/config.json')))
 
     PrefixTreeFactory.pickle_tree(pt, project_root.joinpath('out/fullPrefixTree.p'))

--- a/tests/prefixtree/test_graph.py
+++ b/tests/prefixtree/test_graph.py
@@ -1,0 +1,113 @@
+from typing import List, Tuple
+
+from whatthelog.exceptions import StateDoesNotExistException
+from whatthelog.prefixtree.edge_properties import EdgeProperties
+from whatthelog.prefixtree.graph import Graph
+import pytest
+
+from whatthelog.prefixtree.state import State
+
+
+@pytest.fixture
+def graph():
+
+    graph = Graph()
+    state0 = State(["0"])
+    state1 = State(["1"])
+    state2 = State(["2"])
+    state3 = State(["3"])
+    state4 = State(["4"])
+
+    states = [state0, state1, state2, state3, state4]
+
+    graph.add_state(state0)
+    graph.add_state(state1)
+    graph.add_state(state2)
+    graph.add_state(state3)
+    graph.add_state(state4)
+
+    graph.add_edge(state0, state1, EdgeProperties())
+    graph.add_edge(state0, state2, EdgeProperties())
+    graph.add_edge(state0, state4, EdgeProperties())
+    graph.add_edge(state1, state3, EdgeProperties())
+
+    return graph
+
+
+
+def test_get_state_by_hash(graph: Graph):
+    state = graph.states[0]
+
+    assert graph.get_state_by_hash(hash(state)) == state
+
+
+def test_get_state_by_hash_incorrect(graph: Graph):
+    state = State(["other"])
+
+    with pytest.raises(StateDoesNotExistException):
+        graph.get_state_by_hash(hash(state))
+
+
+def test_add_state(graph: Graph):
+    new_state = State(["5"])
+
+    assert len(graph.states) == 5
+    graph.add_state(new_state)
+
+    assert len(graph.states) == 6
+    assert new_state in graph.states
+    assert graph.get_state_by_hash(hash(new_state)) == new_state
+
+
+def test_add_state_properties_pointers():
+    graph = Graph()
+    state1 = State(["prop"])
+    state2 = State(["prop"])
+
+    graph.add_state(state1)
+    graph.add_state(state2)
+
+    assert graph.size() == 2
+    assert id(state1.properties) == id(state2.properties)
+    assert hash(state1) != hash(state2)
+
+
+def test_add_edge(graph: Graph):
+    state1 = graph.states[1]
+    state2 = graph.states[2]
+    assert state2 not in graph.get_outgoing_states(state1)
+
+    graph.add_edge(state1, state2, EdgeProperties())
+
+    assert state2 in graph.get_outgoing_states(state1)
+
+
+def test_add_edge_incorrect(graph: Graph):
+    state1 = State(["other"])
+
+    assert graph.add_edge(state1, graph.states[0], EdgeProperties()) is False
+    assert graph.add_edge(graph.states[0], state1, EdgeProperties()) is False
+
+
+def test_size(graph: Graph):
+    assert graph.size() == len(graph.states)
+
+
+def test_get_outgoing_props():
+    graph = Graph()
+    state1 = State(["1"])
+    state2 = State(["2"])
+    graph.add_state(state1)
+    graph.add_state(state2)
+
+    props = EdgeProperties(["50"])
+    graph.add_edge(state1, state2, props)
+
+    assert graph.get_outgoing_props(state1) == [props]
+
+
+def test_get_outgoing_states(graph: Graph):
+    state0 = graph.states[0]
+
+    assert len(graph.get_outgoing_states(state0)) == 3
+    assert graph.states[1] in graph.get_outgoing_states(state0)

--- a/tests/prefixtree/test_prefix_tree.py
+++ b/tests/prefixtree/test_prefix_tree.py
@@ -1,7 +1,9 @@
 import pytest
 
+from whatthelog.exceptions import InvalidTreeException
 from whatthelog.prefixtree.prefix_tree import PrefixTree
 from whatthelog.prefixtree.state import State
+
 
 @pytest.fixture()
 def tree():
@@ -19,3 +21,98 @@ def test_add_child(tree: PrefixTree):
 
     assert len(tree.get_children(root)) == 1
     assert tree.get_children(root)[0] == state
+
+
+def test_add_child_incorrect_parent(tree: PrefixTree):
+    with pytest.raises(AssertionError):
+        fake_root = State(["fake"])
+        child = State(["child"])
+
+        tree.add_child(child, fake_root)
+
+
+def test_get_root():
+    root = State(["root"])
+    tree = PrefixTree(root)
+
+    assert tree.get_root() == root
+
+
+def test_get_children(tree: PrefixTree):
+    child1 = State(["child1"])
+    child2 = State(["child2"])
+
+    assert tree.get_children(tree.get_root()) == []
+
+    tree.add_child(child1, tree.get_root())
+    tree.add_child(child2, tree.get_root())
+
+    assert len(tree.get_children(tree.get_root())) == 2
+    assert tree.get_children(tree.get_root())[0] == child1
+    assert tree.get_children(tree.get_root())[1] == child2
+
+
+def test_get_parent(tree: PrefixTree):
+    root = tree.get_root()
+    child1 = State(["child1"])
+
+    tree.add_child(child1, root)
+
+    assert tree.get_parent(child1) == root
+
+
+def test_get_parent_not_in_tree(tree: PrefixTree):
+    root = tree.get_root()
+    child1 = State(["child1"])
+
+    with pytest.raises(AssertionError):
+        tree.get_parent(child1)
+
+
+def test_get_parent_of_root(tree: PrefixTree):
+    assert tree.get_parent(tree.get_root()) is None
+
+
+def test_add_branch(tree: PrefixTree):
+    other = PrefixTree(State(["other"]))
+    child1 = State(["child1"])
+    other.add_child(child1, other.get_root())
+
+    tree.add_branch(other.get_root(), other, tree.get_root())
+
+    assert len(tree.get_children(tree.get_root())) == 1
+    assert len(tree.get_children(tree.get_children(tree.get_root())[0])) == 1
+
+
+def test_merge(tree: PrefixTree):
+    tree.add_child(State(["child1"]), tree.get_root())
+    other = PrefixTree(tree.get_root())
+    other.add_child(State(["child2"]), other.get_root())
+
+    tree.merge(other)
+
+    assert len(tree.get_children(tree.get_root())) == 2
+
+
+def test_merge_complex(tree: PrefixTree):
+    child1 = State(["child1"])
+
+    tree.add_child(child1, tree.get_root())
+    other = PrefixTree(tree.get_root())
+    other.add_child(child1, other.get_root())
+    other.add_child(State(["child2"]), child1)
+    other.add_child(State(["child3"]), child1)
+
+    tree.merge(other)
+
+    tree.merge(other)
+
+    assert len(tree.get_children(tree.get_root())) == 1
+    assert tree.get_children(tree.get_root())[0] == child1
+    assert len(tree.get_children(child1)) == 2
+
+
+def test_merge_different_roots(tree: PrefixTree):
+    with pytest.raises(InvalidTreeException):
+        other = PrefixTree(State(["other"]))
+        tree.merge(other)

--- a/tests/prefixtree/test_prefix_tree_factory.py
+++ b/tests/prefixtree/test_prefix_tree_factory.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from whatthelog.prefixtree.prefix_tree import PrefixTree
+from whatthelog.prefixtree.prefix_tree_factory import PrefixTreeFactory
+
+PROJECT_ROOT = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
+
+
+@pytest.fixture
+def tree() -> PrefixTree:
+    traces_path = "tests/resources/traces_single"
+    tree = PrefixTreeFactory().get_prefix_tree(
+        PROJECT_ROOT.joinpath(traces_path),
+        PROJECT_ROOT.joinpath("resources/config.json"))
+    return tree
+
+
+def test_one_trace(tree: PrefixTree):
+    traces_path = "tests/resources/traces_single"
+
+    with open(PROJECT_ROOT.joinpath(traces_path).joinpath("xx1"), 'r') as file:
+        lines = len(file.readlines())
+
+    assert tree.size() == lines + 1
+
+    root = tree.get_root()
+    assert root.properties.log_templates == [""]
+
+    child2 = None
+    for i in range(tree.size() - 1):
+        if i == 2:
+            child2 = root
+        assert len(tree.get_children(root)) == 1
+        root = tree.get_children(root)[0]
+
+    assert tree.get_children(root) == []
+    assert tree.get_parent(tree.get_root()) is None
+    assert tree.get_parent(child2) == tree.get_children(tree.get_root())[0]
+
+
+def test_multiple_traces():
+    traces_path = "tests/resources/traces"
+    pt = PrefixTreeFactory().get_prefix_tree(PROJECT_ROOT.joinpath(traces_path), PROJECT_ROOT.joinpath("resources/config.json"))
+
+    root = pt.get_root()
+    for _ in range(4):
+        assert len(pt.get_children(root)) == 1
+        root = pt.get_children(root)[0]
+
+    assert len(pt.get_children(root)) == 2
+
+
+def test_pickle(tree: PrefixTree):
+    pickle_file_path = PROJECT_ROOT.joinpath("tests/singleTraceTree.pickle")
+    if os.path.exists(pickle_file_path):
+        os.remove(pickle_file_path)
+
+    assert os.path.exists(pickle_file_path) is False
+
+    PrefixTreeFactory.pickle_tree(tree, pickle_file_path)
+
+    assert os.path.exists(pickle_file_path)
+
+    pt = PrefixTreeFactory.unpickle_tree(pickle_file_path)
+
+    assert pt.matrix.list == tree.matrix.list
+    for x, y in zip(tree.states, pt.states):
+        assert x.is_equivalent(y)
+
+    os.remove(pickle_file_path)
+

--- a/tests/prefixtree/test_state.py
+++ b/tests/prefixtree/test_state.py
@@ -1,0 +1,17 @@
+from whatthelog.prefixtree.state import State
+
+
+def test_hash():
+    x = State(["root"])
+    y = State(["root"])
+
+    assert hash(x) != hash(y)
+
+
+def test_is_equivalent():
+    x = State(["root"])
+    y = State(["root"])
+    z = State(["root", "other"])
+
+    assert x.is_equivalent(y)
+    assert x.is_equivalent(z) is False

--- a/tests/resources/traces/xx1
+++ b/tests/resources/traces/xx1
@@ -1,0 +1,36 @@
+2020-Mar-01 16:36:36.093094983 LedgerConsensus:NFO Entering consensus process, validating, synced=yes
+2020-Mar-01 16:36:36.094601541 LedgerConsensus:NFO Consensus mode change before=proposing, after=proposing
+2020-Mar-01 16:36:38.842049571 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842104531 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842116439 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842124914 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842133070 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842141140 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842149255 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842157698 LedgerConsensus:NFO No change (NO) : weight 11, percent 40
+2020-Mar-01 16:36:38.842165766 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842173985 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842182432 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842190503 LedgerConsensus:NFO No change (NO) : weight 27, percent 40
+2020-Mar-01 16:36:38.842198528 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842226350 LedgerConsensus:NFO No change (NO) : weight 30, percent 40
+2020-Mar-01 16:36:38.842235650 LedgerConsensus:NFO No change (NO) : weight 30, percent 40
+2020-Mar-01 16:36:38.842243855 LedgerConsensus:NFO No change (NO) : weight 11, percent 40
+2020-Mar-01 16:36:38.842252109 LedgerConsensus:NFO No change (NO) : weight 22, percent 40
+2020-Mar-01 16:36:38.842260528 LedgerConsensus:NFO No change (NO) : weight 47, percent 40
+2020-Mar-01 16:36:38.842268466 LedgerConsensus:NFO No change (NO) : weight 27, percent 40
+2020-Mar-01 16:36:38.842281211 LedgerConsensus:NFO No change (NO) : weight 16, percent 40
+2020-Mar-01 16:36:38.842290043 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842298196 LedgerConsensus:NFO No change (NO) : weight 13, percent 40
+2020-Mar-01 16:36:38.842306364 LedgerConsensus:NFO No change (YES) : weight 91, percent 40
+2020-Mar-01 16:36:38.842314612 LedgerConsensus:NFO No change (NO) : weight 11, percent 40
+2020-Mar-01 16:36:38.842355807 LedgerConsensus:NFO Proposers:35 nw:50 thrV:18 thrC:27
+2020-Mar-01 16:36:38.842368025 LedgerConsensus:NFO Position change: CTime 636395800, tx D778FFFC8857EA3F0EB791B67AFBB9AE428F6250693B4AC75D3F4FB6FDC2AF77
+2020-Mar-01 16:36:39.843144906 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 16:36:39.843205299 LedgerConsensus:NFO Proposers:35 nw:65 thrV:23 thrC:27
+2020-Mar-01 16:36:39.843537122 LedgerConsensus:NFO Converge cutoff (35 participants)
+2020-Mar-01 16:36:40.050739882 LedgerConsensus:NFO CNF Val 890DFE9B74CF937A44638198CF4D078F2535F346D122BF275D144868026DEC2C
+2020-Mar-01 16:36:40.143506235 LedgerConsensus:NFO We closed at 636395796
+2020-Mar-01 16:36:40.144089526 LedgerConsensus:NFO 18 time votes for 636395796
+2020-Mar-01 16:36:40.144224694 LedgerConsensus:NFO 17 time votes for 636395797
+2020-Mar-01 16:36:40.144360914 LedgerConsensus:NFO Our close offset is estimated at 0 (36)

--- a/tests/resources/traces/xx2
+++ b/tests/resources/traces/xx2
@@ -1,0 +1,25 @@
+2020-Mar-01 17:59:01.084940419 LedgerConsensus:NFO Entering consensus process, validating, synced=yes
+2020-Mar-01 17:59:01.085347693 LedgerConsensus:NFO Consensus mode change before=proposing, after=proposing
+2020-Mar-01 17:59:03.990988482 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 17:59:03.991049507 LedgerConsensus:NFO No change (NO) : weight 27, percent 40
+2020-Mar-01 17:59:03.991060360 LedgerConsensus:NFO No change (NO) : weight 30, percent 40
+2020-Mar-01 17:59:03.991117955 LedgerConsensus:NFO No change (NO) : weight 30, percent 40
+2020-Mar-01 17:59:03.991139127 LedgerConsensus:NFO No change (NO) : weight 27, percent 40
+2020-Mar-01 17:59:03.991159772 LedgerConsensus:NFO No change (NO) : weight 22, percent 40
+2020-Mar-01 17:59:03.991308649 LedgerConsensus:NFO No change (YES) : weight 94, percent 40
+2020-Mar-01 17:59:03.991351873 LedgerConsensus:NFO No change (YES) : weight 94, percent 40
+2020-Mar-01 17:59:03.991455635 LedgerConsensus:NFO Proposers:35 nw:50 thrV:18 thrC:27
+2020-Mar-01 17:59:03.991477670 LedgerConsensus:NFO Position change: CTime 636400740, tx 11AB56EE8DE54AC1B7F37058FAD5F32B0E632D017F8D1E36468DCBB7D66526C3
+2020-Mar-01 17:59:04.992189113 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 17:59:04.992247162 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 17:59:04.992258632 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 17:59:04.992267837 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 17:59:04.992276008 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 17:59:04.992284538 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 17:59:04.992295731 LedgerConsensus:NFO Proposers:35 nw:65 thrV:23 thrC:27
+2020-Mar-01 17:59:04.992490697 LedgerConsensus:NFO Converge cutoff (35 participants)
+2020-Mar-01 17:59:05.045277481 LedgerConsensus:NFO CNF Val 1F332A7C7825D398EA1BE36CF11C25ECC271005573E748058661EB614D01DED1
+2020-Mar-01 17:59:05.093347513 LedgerConsensus:NFO We closed at 636400741
+2020-Mar-01 17:59:05.093401039 LedgerConsensus:NFO 4 time votes for 636400741
+2020-Mar-01 17:59:05.093424142 LedgerConsensus:NFO 31 time votes for 636400742
+2020-Mar-01 17:59:05.093492508 LedgerConsensus:NFO Our close offset is estimated at 1 (36)

--- a/tests/resources/traces/xx3
+++ b/tests/resources/traces/xx3
@@ -1,0 +1,17 @@
+2020-Mar-01 17:59:28.222404125 LedgerConsensus:NFO Entering consensus process, validating, synced=yes
+2020-Mar-01 17:59:28.223319430 LedgerConsensus:NFO Consensus mode change before=proposing, after=proposing
+2020-Mar-01 17:59:31.034897734 LedgerConsensus:NFO No change (NO) : weight 5, percent 40
+2020-Mar-01 17:59:31.034960133 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 17:59:31.034972543 LedgerConsensus:NFO No change (NO) : weight 5, percent 40
+2020-Mar-01 17:59:31.034981352 LedgerConsensus:NFO No change (YES) : weight 80, percent 40
+2020-Mar-01 17:59:31.034990146 LedgerConsensus:NFO No change (NO) : weight 22, percent 40
+2020-Mar-01 17:59:31.034998636 LedgerConsensus:NFO No change (YES) : weight 80, percent 40
+2020-Mar-01 17:59:31.035023991 LedgerConsensus:NFO No change (NO) : weight 8, percent 40
+2020-Mar-01 17:59:31.035034738 LedgerConsensus:NFO Proposers:35 nw:50 thrV:18 thrC:27
+2020-Mar-01 17:59:32.035576274 LedgerConsensus:NFO Proposers:35 nw:65 thrV:23 thrC:27
+2020-Mar-01 17:59:32.036064003 LedgerConsensus:NFO Converge cutoff (35 participants)
+2020-Mar-01 17:59:32.154686167 LedgerConsensus:NFO CNF Val 63B64AF86860420A1A0C7055131AC749F529F985385AA40A96249DB3411515B4
+2020-Mar-01 17:59:32.213034656 LedgerConsensus:NFO We closed at 636400769
+2020-Mar-01 17:59:32.213086140 LedgerConsensus:NFO 11 time votes for 636400768
+2020-Mar-01 17:59:32.213097088 LedgerConsensus:NFO 24 time votes for 636400769
+2020-Mar-01 17:59:32.213106371 LedgerConsensus:NFO Our close offset is estimated at 0 (36)

--- a/tests/resources/traces/xx4
+++ b/tests/resources/traces/xx4
@@ -1,0 +1,13 @@
+2020-Mar-01 18:01:29.349678451 LedgerConsensus:NFO Entering consensus process, validating, synced=yes
+2020-Mar-01 18:01:29.350125055 LedgerConsensus:NFO Consensus mode change before=proposing, after=proposing
+2020-Mar-01 18:01:32.245281076 LedgerConsensus:NFO No change (NO) : weight 22, percent 40
+2020-Mar-01 18:01:32.245323294 LedgerConsensus:NFO No change (NO) : weight 22, percent 40
+2020-Mar-01 18:01:32.245351250 LedgerConsensus:NFO Proposers:35 nw:50 thrV:18 thrC:27
+2020-Mar-01 18:01:32.245378962 LedgerConsensus:NFO Position change: CTime 636400890, tx 7D142692FCE485F859EA37282CEF7550699A2417274599F7BFCD719E84FF37F6
+2020-Mar-01 18:01:33.245984277 LedgerConsensus:NFO Proposers:35 nw:65 thrV:23 thrC:27
+2020-Mar-01 18:01:33.246280266 LedgerConsensus:NFO Converge cutoff (35 participants)
+2020-Mar-01 18:01:33.326309469 LedgerConsensus:NFO CNF Val 5405582F450319D80DC2D746B695780BFC9842AA158EB69EFB45C668569CD4F2
+2020-Mar-01 18:01:33.372106130 LedgerConsensus:NFO We closed at 636400890
+2020-Mar-01 18:01:33.372189394 LedgerConsensus:NFO 18 time votes for 636400889
+2020-Mar-01 18:01:33.372232344 LedgerConsensus:NFO 17 time votes for 636400890
+2020-Mar-01 18:01:33.372284522 LedgerConsensus:NFO Our close offset is estimated at 0 (36)

--- a/tests/resources/traces/xx5
+++ b/tests/resources/traces/xx5
@@ -1,0 +1,16 @@
+2020-Mar-01 18:02:41.458573523 LedgerConsensus:NFO Entering consensus process, validating, synced=yes
+2020-Mar-01 18:02:41.459102614 LedgerConsensus:NFO Consensus mode change before=proposing, after=proposing
+2020-Mar-01 18:02:44.362657469 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 18:02:44.362814926 LedgerConsensus:NFO No change (YES) : weight 94, percent 40
+2020-Mar-01 18:02:44.363018731 LedgerConsensus:NFO No change (YES) : weight 94, percent 40
+2020-Mar-01 18:02:44.363166401 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 18:02:44.363253245 LedgerConsensus:NFO No change (YES) : weight 94, percent 40
+2020-Mar-01 18:02:44.363413832 LedgerConsensus:NFO No change (NO) : weight 13, percent 40
+2020-Mar-01 18:02:44.363489901 LedgerConsensus:NFO No change (YES) : weight 94, percent 40
+2020-Mar-01 18:02:44.363627203 LedgerConsensus:NFO Proposers:35 nw:50 thrV:18 thrC:27
+2020-Mar-01 18:02:44.363804178 LedgerConsensus:NFO Converge cutoff (35 participants)
+2020-Mar-01 18:02:44.465935668 LedgerConsensus:NFO CNF Val F830C3AE62B40ABE039E4E66B434D94EDC375186E3C4710ACF95646E5428E2E3
+2020-Mar-01 18:02:44.482591115 LedgerConsensus:NFO We closed at 636400962
+2020-Mar-01 18:02:44.482628799 LedgerConsensus:NFO 2 time votes for 636400961
+2020-Mar-01 18:02:44.482640984 LedgerConsensus:NFO 33 time votes for 636400962
+2020-Mar-01 18:02:44.482650493 LedgerConsensus:NFO Our close offset is estimated at 0 (36)

--- a/tests/resources/traces_single/xx1
+++ b/tests/resources/traces_single/xx1
@@ -1,0 +1,36 @@
+2020-Mar-01 16:36:36.093094983 LedgerConsensus:NFO Entering consensus process, validating, synced=yes
+2020-Mar-01 16:36:36.094601541 LedgerConsensus:NFO Consensus mode change before=proposing, after=proposing
+2020-Mar-01 16:36:38.842049571 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842104531 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842116439 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842124914 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842133070 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842141140 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842149255 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842157698 LedgerConsensus:NFO No change (NO) : weight 11, percent 40
+2020-Mar-01 16:36:38.842165766 LedgerConsensus:NFO No change (NO) : weight 2, percent 40
+2020-Mar-01 16:36:38.842173985 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842182432 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842190503 LedgerConsensus:NFO No change (NO) : weight 27, percent 40
+2020-Mar-01 16:36:38.842198528 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842226350 LedgerConsensus:NFO No change (NO) : weight 30, percent 40
+2020-Mar-01 16:36:38.842235650 LedgerConsensus:NFO No change (NO) : weight 30, percent 40
+2020-Mar-01 16:36:38.842243855 LedgerConsensus:NFO No change (NO) : weight 11, percent 40
+2020-Mar-01 16:36:38.842252109 LedgerConsensus:NFO No change (NO) : weight 22, percent 40
+2020-Mar-01 16:36:38.842260528 LedgerConsensus:NFO No change (NO) : weight 47, percent 40
+2020-Mar-01 16:36:38.842268466 LedgerConsensus:NFO No change (NO) : weight 27, percent 40
+2020-Mar-01 16:36:38.842281211 LedgerConsensus:NFO No change (NO) : weight 16, percent 40
+2020-Mar-01 16:36:38.842290043 LedgerConsensus:NFO No change (YES) : weight 97, percent 40
+2020-Mar-01 16:36:38.842298196 LedgerConsensus:NFO No change (NO) : weight 13, percent 40
+2020-Mar-01 16:36:38.842306364 LedgerConsensus:NFO No change (YES) : weight 91, percent 40
+2020-Mar-01 16:36:38.842314612 LedgerConsensus:NFO No change (NO) : weight 11, percent 40
+2020-Mar-01 16:36:38.842355807 LedgerConsensus:NFO Proposers:35 nw:50 thrV:18 thrC:27
+2020-Mar-01 16:36:38.842368025 LedgerConsensus:NFO Position change: CTime 636395800, tx D778FFFC8857EA3F0EB791B67AFBB9AE428F6250693B4AC75D3F4FB6FDC2AF77
+2020-Mar-01 16:36:39.843144906 LedgerConsensus:NFO No change (NO) : weight 2, percent 60
+2020-Mar-01 16:36:39.843205299 LedgerConsensus:NFO Proposers:35 nw:65 thrV:23 thrC:27
+2020-Mar-01 16:36:39.843537122 LedgerConsensus:NFO Converge cutoff (35 participants)
+2020-Mar-01 16:36:40.050739882 LedgerConsensus:NFO CNF Val 890DFE9B74CF937A44638198CF4D078F2535F346D122BF275D144868026DEC2C
+2020-Mar-01 16:36:40.143506235 LedgerConsensus:NFO We closed at 636395796
+2020-Mar-01 16:36:40.144089526 LedgerConsensus:NFO 18 time votes for 636395796
+2020-Mar-01 16:36:40.144224694 LedgerConsensus:NFO 17 time votes for 636395797
+2020-Mar-01 16:36:40.144360914 LedgerConsensus:NFO Our close offset is estimated at 0 (36)

--- a/tests/syntaxtree/test_parser.py
+++ b/tests/syntaxtree/test_parser.py
@@ -1,16 +1,20 @@
+import os
+from pathlib import Path
+
 from whatthelog.syntaxtree.parser import Parser
 from whatthelog.syntaxtree.syntax_tree import SyntaxTree
 
+PROJECT_ROOT = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
 
 def test_parse_file_simple():
-    tree = Parser().parse_file("tests/resources/test_simple.json")
+    tree = Parser().parse_file(PROJECT_ROOT.joinpath("tests/resources/test_simple.json"))
     expected = SyntaxTree("node", "[node]", False)
 
     assert tree == expected
 
 
 def test_parse_file_complex():
-    tree = Parser().parse_file("tests/resources/test.json")
+    tree = Parser().parse_file(PROJECT_ROOT.joinpath("tests/resources/test.json"))
 
     expected = SyntaxTree("root", "[root]", False)
     node1 = SyntaxTree("node1", "[node1]", False)

--- a/whatthelog/exceptions.py
+++ b/whatthelog/exceptions.py
@@ -5,10 +5,19 @@ from dataclasses import dataclass, field
 class UnidentifiedLogException(Exception):
     message: str = field(default="Log message not found in syntax tree!")
 
+
 @dataclass(frozen=True)
 class InvalidTreeException(Exception):
     message: str = field(default="Tree is invalid")
 
+
 @dataclass(frozen=True)
 class StateAlreadyExistsException(Exception):
     message: str = field(default="Attempted to add duplicate state to tree!")
+
+
+@dataclass(frozen=True)
+class StateDoesNotExistException(Exception):
+    message: str = field(default="State does not exist in graph")
+
+

--- a/whatthelog/prefixtree/graph.py
+++ b/whatthelog/prefixtree/graph.py
@@ -14,7 +14,7 @@ from typing import List, Union, Dict
 
 from whatthelog.prefixtree.state import State
 from whatthelog.auto_printer import AutoPrinter
-from whatthelog.exceptions import StateAlreadyExistsException
+from whatthelog.exceptions import StateAlreadyExistsException, StateDoesNotExistException
 from whatthelog.prefixtree.sparse_matrix import SparseMatrix
 from whatthelog.prefixtree.edge_properties import EdgeProperties
 
@@ -42,6 +42,9 @@ class Graph(AutoPrinter):
         :param state_hash: the hash of the state to fetch
         :return: the state object
         """
+        if state_hash not in self.state_indices_by_hash:
+            raise StateDoesNotExistException()
+
         return self.states[self.state_indices_by_hash[state_hash]]
 
     def add_state(self, state: State):

--- a/whatthelog/prefixtree/prefix_tree.py
+++ b/whatthelog/prefixtree/prefix_tree.py
@@ -101,7 +101,6 @@ class PrefixTree(Graph):
         """
         assert state in self
         parents = self.matrix.get_parents(self.state_indices_by_hash[hash(state)])
-        print(parents)
         assert len(parents) <= 1, "Edge has more than one parent!"
 
         if parents is None or len(parents) == 0:

--- a/whatthelog/prefixtree/prefix_tree.py
+++ b/whatthelog/prefixtree/prefix_tree.py
@@ -99,8 +99,9 @@ class PrefixTree(Graph):
         :param state: State to get parent of
         :return: Parent of state. If None state is the root.
         """
-
+        assert state in self
         parents = self.matrix.get_parents(self.state_indices_by_hash[hash(state)])
+        print(parents)
         assert len(parents) <= 1, "Edge has more than one parent!"
 
         if parents is None or len(parents) == 0:

--- a/whatthelog/prefixtree/prefix_tree_factory.py
+++ b/whatthelog/prefixtree/prefix_tree_factory.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 
 from whatthelog.prefixtree.prefix_tree import PrefixTree
 from whatthelog.prefixtree.state import State
+from whatthelog.prefixtree.visualizer import Visualizer
 from whatthelog.syntaxtree.parser import Parser
 from whatthelog.exceptions import UnidentifiedLogException
 from whatthelog.syntaxtree.syntax_tree import SyntaxTree
@@ -107,7 +108,6 @@ class PrefixTreeFactory(AutoPrinter):
         for filename in pbar:
             filepath = str(Path(log_dir).joinpath(filename)).strip()
             PrefixTreeFactory.__parse_trace(filepath, syntax_tree, prefix_tree)
-
         return prefix_tree
 
     @staticmethod

--- a/whatthelog/prefixtree/sparse_matrix.py
+++ b/whatthelog/prefixtree/sparse_matrix.py
@@ -81,17 +81,18 @@ class SparseMatrix:
         :return a list of tuples (child_number, value), or None if no child found.
         """
         index: int = self.bisearch(search_list, str(item) + self.separator)
-        if index != self.size:
-            current = self.get_values(index)
+
+        if index != len(search_list):
+            current = self.get_values(search_list, index)
             result = [(current[1], current[2])]
             idx = index - 1
-            while idx >= 0 and self.list[idx].startswith(str(item) + self.separator):
-                current = self.get_values(idx)
+            while idx >= 0 and search_list[idx].startswith(str(item) + self.separator):
+                current = self.get_values(search_list, idx)
                 result.append((current[1], current[2]))
                 idx -= 1
             idx = index + 1
-            while idx < self.size and self.list[idx].startswith(str(item) + self.separator):
-                current = self.get_values(idx)
+            while idx < self.size and search_list[idx].startswith(str(item) + self.separator):
+                current = self.get_values(search_list, idx)
                 result.append((current[1], current[2]))
                 idx += 1
             return result
@@ -107,12 +108,13 @@ class SparseMatrix:
         """
         return self.__find_children(self.list, item)
 
-    def bisearch(self, arr: List[str], target: str) -> int:
+    @staticmethod
+    def bisearch(arr: List[str], target: str) -> int:
         """
         Perform a binary search on the prefix (of unspecified length) of the elements
         """
         low: int = 0
-        high: int = self.size - 1
+        high: int = len(arr) - 1
         while high >= low:
             ix = (low + high) // 2
             if arr[ix].startswith(target):  # todo make this more efficient maybe?
@@ -122,19 +124,20 @@ class SparseMatrix:
             else:
                 low = ix + 1
 
-        return self.size
+        return len(arr)
 
-    def get_values(self, index: int) -> Tuple[int, int, str]:
+    @staticmethod
+    def get_values(array: List[str],  index: int) -> Tuple[int, int, str]:
         """
         Retrieves the tuple of coordinates and value for the given index.
         Raises an exception if the index is out of bounds.
         :param index: the index of the tuple to fetch.
         :return a tuple in the form(start_node, end_node, edge_value)
         """
-        if index < 0 or index >= self.size:
+        if index < 0 or index >= len(array):
             raise IndexError
 
-        value: str = self.list[index]
+        value: str = array[index]
         strings = value.split('.', 2)
         return int(strings[0]), int(strings[1]), strings[2]
 
@@ -149,8 +152,16 @@ class SparseMatrix:
         reverse = []
         for item in copy:
             parent, child, props = item.split('.', 2)
-            reverse.append(f"{child}.{parent}.{props}")
-        return [tup[0] for tup in self.__find_children(reverse, i)]
+            bisect.insort_right(reverse, f"{child}.{parent}.{props}")
+        print("list: ", self.list)
+        print("reverse: ", reverse)
+        children = self.__find_children(reverse, i)
+        print(f"children of {i}: ", children)
+
+        return [tup[0] for tup in self.__find_children(reverse, i)] if children is not None else []
 
     def __len__(self):
         return self.size
+
+    def __str__(self):
+        return str(self.list)

--- a/whatthelog/prefixtree/sparse_matrix.py
+++ b/whatthelog/prefixtree/sparse_matrix.py
@@ -153,10 +153,8 @@ class SparseMatrix:
         for item in copy:
             parent, child, props = item.split('.', 2)
             bisect.insort_right(reverse, f"{child}.{parent}.{props}")
-        print("list: ", self.list)
-        print("reverse: ", reverse)
+
         children = self.__find_children(reverse, i)
-        print(f"children of {i}: ", children)
 
         return [tup[0] for tup in self.__find_children(reverse, i)] if children is not None else []
 

--- a/whatthelog/prefixtree/visualizer.py
+++ b/whatthelog/prefixtree/visualizer.py
@@ -68,8 +68,7 @@ class Visualizer:
 
             while level_size > 0:
                 state = queue.pop(0)
-                print("state:", state)
-                print(self.prefix_tree.get_parent(state))
+
                 self.G.add_edge(id(self.prefix_tree.get_parent(state)),
                                 id(state))
 

--- a/whatthelog/prefixtree/visualizer.py
+++ b/whatthelog/prefixtree/visualizer.py
@@ -1,0 +1,102 @@
+from pprint import pprint
+from typing import Tuple, Dict, List
+
+import networkx as nx
+import matplotlib.pyplot as plt
+
+from networkx.drawing.nx_pydot import graphviz_layout
+
+from whatthelog.prefixtree.prefix_tree import PrefixTree
+
+
+class Visualizer:
+    """
+    Class to visualize Prefix Tree.
+    """
+
+    def __init__(self, prefix_tree: PrefixTree):
+        """
+        Visualizer constructor.
+        :param prefix_tree: Prefix tree to visualize
+        """
+        self.prefix_tree = prefix_tree
+        self.G = nx.DiGraph()
+        self.label_mapping = {"": 0}
+
+    def visualize(self, file_path="../resources/prefixtree.png"):
+        """
+        Method to visualize the prefix tree.
+        :param file_path: Path to save the file, if None dont save
+        :return: None
+        """
+        labels, branches, depth = self.__populate_graph()
+
+        plt.figure(1, figsize=(branches + 1, depth / 2 + 1))
+
+        pos = graphviz_layout(self.G, prog="dot")
+        nx.draw_networkx_labels(self.G, pos, labels)
+        nx.draw(self.G, pos, node_size=500, font_size=6)
+
+        plt.tight_layout()
+        if file_path is not None:
+            plt.savefig(file_path)
+
+        plt.show()
+
+        pprint(self.label_mapping)
+
+    def __populate_graph(self) -> Tuple[Dict[int, str], int, int]:
+        """
+        Method that populates the graph by traversing the prefix tree
+         using breadth first.
+        While traversing also keep track of number of branches
+         and maximum depth.
+        :return: 3Tuple containing
+                a dictionary mapping unique node ids to labels (log ids),
+                number of branches,
+                maximum depth of tree
+        """
+
+        labels = {id(self.prefix_tree.get_root()): self.get_label(self.prefix_tree.get_root().properties.log_templates)}
+
+        queue = self.prefix_tree.get_children(self.prefix_tree.get_root())
+        branches = 1
+        depth = 1
+
+        while len(queue) != 0:
+            level_size = len(queue)
+
+            while level_size > 0:
+                state = queue.pop(0)
+                print("state:", state)
+                print(self.prefix_tree.get_parent(state))
+                self.G.add_edge(id(self.prefix_tree.get_parent(state)),
+                                id(state))
+
+                labels[id(state)] = self.get_label(state.properties.log_templates)
+
+                children = self.prefix_tree.get_children(state)
+
+                if len(children) > 1:
+                    branches += len(children) - 1
+
+                queue += children
+                level_size -= 1
+            depth += 1
+
+        return labels, branches, depth
+
+    def get_label(self, log_templates: List[str]) -> str:
+        label = ""
+        if len(log_templates) > 1:
+            label += "["
+        for log_template in log_templates:
+            if log_template not in self.label_mapping:
+                self.label_mapping[log_template] = len(self.label_mapping)
+
+            label += str(self.label_mapping[log_template])
+
+        if len(log_templates) > 1:
+            label += "]"
+
+        return label


### PR DESCRIPTION
This pull request includes:
- Added tests for prefix tree
- Fixed bugs in sparse matrix. Specifically fixed __find_children method so that it actually works on the input list (before it took an input list to find children on but still worked on self). The same fix for bisearch and getvalues. Also fixed the get_parents method which had a bug where after reversing and appending to the new list the ordering would be lost. Hence now they are inserted using binary search into the new list.
- Brought the visualizer back since its helpful for debugging smaller cases
